### PR TITLE
Fix execution of tests after upgrade of maven-surefire-plugin

### DIFF
--- a/osgiservice/osgiservice.database/pom.xml
+++ b/osgiservice/osgiservice.database/pom.xml
@@ -45,16 +45,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/osgiservice/osgiservice.users/pom.xml
+++ b/osgiservice/osgiservice.users/pom.xml
@@ -56,16 +56,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Without this change

```
...
[INFO] --- surefire:3.1.2:test (default-test) @ osgiservice.database ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] --- surefire:3.1.2:test (default-test) @ osgiservice.users ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
...
```

and after this change

```
...
[INFO] --- surefire:3.1.2:test (default-test) @ osgiservice.database ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
...
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] --- surefire:3.1.2:test (default-test) @ osgiservice.users ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
...
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
...
```